### PR TITLE
Add 500 error handler and Dockerfile update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
-FROM ubuntu:20.04
-RUN apt-get update && apt-get install -y python3 python3-pip
-RUN pip3 install flask
-COPY app.py /opt/
-ENTRYPOINT FLASK_APP=/opt/app.py flask run --host=0.0.0.0 --port=8080
+FROM python:3.11-slim
+WORKDIR /opt
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app.py .
+ENV FLASK_APP=app.py
+EXPOSE 8080
+CMD ["flask", "run", "--host=0.0.0.0", "--port=8080"]

--- a/app.py
+++ b/app.py
@@ -14,5 +14,16 @@ def hello():
 def health():
     return jsonify(status='OK'), 200
 
+# route to deliberately raise an exception for testing
+@app.route('/cause_error')
+def cause_error():
+    raise Exception('Intentional error')
+
+
+@app.errorhandler(500)
+def internal_error(error):
+    """Return JSON when an internal server error occurs."""
+    return jsonify(error='Internal Server Error'), 500
+
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=8080)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -9,3 +9,10 @@ def test_root_route_returns_200():
     client = app.app.test_client()
     response = client.get('/')
     assert response.status_code == 200
+
+
+def test_internal_server_error_handler():
+    client = app.app.test_client()
+    response = client.get('/cause_error')
+    assert response.status_code == 500
+    assert response.get_json() == {"error": "Internal Server Error"}


### PR DESCRIPTION
## Summary
- handle HTTP 500 responses with JSON
- add endpoint to trigger a server error for testing
- update unit tests for new error handler
- create slimmer Dockerfile using python:3.11-slim

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887334149608332a39c40816c71bc4f