### PR TITLE
Add 500 handler and docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-FROM ubuntu:20.04
-RUN apt-get update && apt-get install -y python3 python3-pip
-RUN pip3 install flask
-COPY app.py /opt/
-ENTRYPOINT FLASK_APP=/opt/app.py flask run --host=0.0.0.0 --port=8080
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app.py ./
+ENV FLASK_APP=app.py
+CMD ["flask", "run", "--host=0.0.0.0", "--port=8080"]

--- a/README.md
+++ b/README.md
@@ -42,3 +42,12 @@ http://<IP>:5000                            => Welcome
 http://<IP>:5000/how%20are%20you            => I am good, how about you?
 http://<IP>:5000/health                  => {"status": "OK"}
 ```
+
+## Docker
+
+Build the container image and run it:
+
+```bash
+docker build -t simple-webapp .
+docker run -p 8080:8080 simple-webapp
+```

--- a/app.py
+++ b/app.py
@@ -14,5 +14,14 @@ def hello():
 def health():
     return jsonify(status='OK'), 200
 
+@app.route('/error')
+def trigger_error():
+    raise RuntimeError('Intentional error')
+
+
+@app.errorhandler(500)
+def internal_server_error(error):
+    return jsonify(error='Internal Server Error'), 500
+
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=8080)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -9,3 +9,10 @@ def test_root_route_returns_200():
     client = app.app.test_client()
     response = client.get('/')
     assert response.status_code == 200
+
+
+def test_error_route_returns_custom_500():
+    client = app.app.test_client()
+    response = client.get('/error')
+    assert response.status_code == 500
+    assert response.get_json() == {'error': 'Internal Server Error'}


### PR DESCRIPTION
## Summary
- add route to test server errors and register a 500 error handler
- update unit tests for the new 500 behavior
- replace the Dockerfile with a slim python image and pip install
- document docker usage in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887334149608332a39c40816c71bc4f